### PR TITLE
Adicionando .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+**/.DS_Store
+*~
+*.swp
+*.tmp
+*.aux
+*.log
+*.out
+node_modules


### PR DESCRIPTION
Adicionando .gitignore. Isso é importante para desconsiderarmos arquivos temporários ou inúteis no repositório.